### PR TITLE
fix: Fix NullPointerException in BookmarkViewModel initialization

### DIFF
--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/recents/BookmarkViewModel.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/recents/BookmarkViewModel.kt
@@ -44,8 +44,8 @@ class BookmarkViewModel @Inject constructor(
 
     private var _screenState = MutableStateFlow(ScreenState.EMPTY)
     private var _showSearchResults = MutableStateFlow(false)
-    private var _searchQuery = MutableStateFlow("")
-    private var _searchResults = MutableStateFlow<List<Bookmark>>(emptyList())
+    private val _searchQuery = MutableStateFlow("")
+    private val _searchResults = MutableStateFlow<List<Bookmark>>(emptyList())
 
     init {
         viewModelScope.launch {

--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/recents/BookmarkViewModel.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/recents/BookmarkViewModel.kt
@@ -44,6 +44,8 @@ class BookmarkViewModel @Inject constructor(
 
     private var _screenState = MutableStateFlow(ScreenState.EMPTY)
     private var _showSearchResults = MutableStateFlow(false)
+    private var _searchQuery = MutableStateFlow("")
+    private var _searchResults = MutableStateFlow<List<Bookmark>>(emptyList())
 
     init {
         viewModelScope.launch {
@@ -166,12 +168,6 @@ class BookmarkViewModel @Inject constructor(
             storageService.setUserId(accountService.getUserId())
         }
     }
-
-    private var _searchQuery = MutableStateFlow("")
-//    val searchQuery: Flow<String> = _searchQuery
-
-    private var _searchResults = MutableStateFlow<List<Bookmark>>(emptyList())
-//    val searchResults: Flow<List<Bookmark>?> = _searchResults
 
     private fun searchBookmarks() {
         viewModelScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
Fixed a property initialization order issue that caused a NullPointerException when accessing _showSearchResults.value in the init block. The crash occurred because search-related properties (_searchQuery and _searchResults) were declared after init blocks, creating a fragmented initialization order.

Changes:
- Moved _searchQuery and _searchResults declarations to be with other state properties
- Ensured all properties are initialized before init blocks execute
- Removed duplicate property declarations

Fixes crash: java.lang.NullPointerException at BookmarkViewModel.kt:53

🤖 Generated with [Claude Code](https://claude.com/claude-code)