### PR TITLE
Implement Google Sign-In with Firebase

### DIFF
--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/AuthViewModel.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/AuthViewModel.kt
@@ -33,6 +33,12 @@ class AuthViewModel @Inject constructor(
 
     fun hasUser() = accountService.hasUser()
 
+    fun signOut() {
+        accountService.signOut()
+        _user.value = null
+        _userDetails.value = null
+    }
+
     fun onSignInResult(result: FirebaseAuthUIAuthenticationResult) {
         val response = result.idpResponse
         if (result.resultCode == RESULT_OK) {

--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/AuthViewModel.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/AuthViewModel.kt
@@ -12,12 +12,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import xyz.graphitenerd.tassel.R
 import xyz.graphitenerd.tassel.service.AccountService
+import xyz.graphitenerd.tassel.service.StorageService
 import xyz.graphitenerd.tassel.service.UserDetails
 import javax.inject.Inject
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val accountService: AccountService,
+    private val storageService: StorageService,
 ): ViewModel() {
 
 //    lateinit var user: FirebaseUser
@@ -47,6 +49,9 @@ class AuthViewModel @Inject constructor(
             if (firebaseUser != null) {
                 _user.value = firebaseUser
                 _userDetails.value = accountService.getUserDetails()
+
+                // Initialize Firebase sync with the authenticated user's ID
+                initializeFirebaseSync()
             }
             // ...
         } else {
@@ -54,6 +59,20 @@ class AuthViewModel @Inject constructor(
             // sign-in flow using the back button. Otherwise check
             // response.getError().getErrorCode() and handle the error.
             // ...
+        }
+    }
+
+    /**
+     * Initializes Firebase sync by setting the user ID in StorageService.
+     * This ensures that bookmarks and folders sync to the correct user's
+     * Firestore collection after successful authentication.
+     */
+    private fun initializeFirebaseSync() {
+        if (accountService.hasUser() && !storageService.isUserSet()) {
+            val userId = accountService.getUserId()
+            if (userId.isNotEmpty()) {
+                storageService.setUserId(userId)
+            }
         }
     }
 

--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/TasselNavHost.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/TasselNavHost.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.paging.compose.collectAsLazyPagingItems
+import xyz.graphitenerd.tassel.screens.auth.LoginScreen
 import xyz.graphitenerd.tassel.screens.create.AddBookmarkScreen
 import xyz.graphitenerd.tassel.screens.create.NewBookmarkViewModel
 import xyz.graphitenerd.tassel.screens.folders.FolderScreen
@@ -25,6 +26,7 @@ import xyz.graphitenerd.tassel.screens.settings.SettingsScreen
 fun TasselNavHost(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
+    startDestination: String = Screens.RECENTS.name,
     addNewBookmarkViewModel: NewBookmarkViewModel = hiltViewModel(),
     bookmarkViewModel: BookmarkViewModel = hiltViewModel(),
     folderViewModel: FolderViewModel = hiltViewModel(),
@@ -42,8 +44,18 @@ fun TasselNavHost(
     NavHost(
         modifier = modifier.fillMaxSize(),
         navController = navController,
-        startDestination = Screens.RECENTS.name
+        startDestination = startDestination
     ) {
+        composable(Screens.LOGIN.name) {
+            LoginScreen(
+                authViewModel = authViewModel,
+                onSignInSuccess = {
+                    navController.navigate(Screens.RECENTS.name) {
+                        popUpTo(Screens.LOGIN.name) { inclusive = true }
+                    }
+                }
+            )
+        }
         composable(Screens.RECENTS.name) {
             RecentScreen(
                 bookmarks = bookmarks,
@@ -82,12 +94,18 @@ fun TasselNavHost(
         composable(Screens.SETTINGS.name) {
             SettingsScreen(
                 authViewModel = authViewModel,
+                onSignOut = {
+                    navController.navigate(Screens.LOGIN.name) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                }
             )
         }
     }
 }
 
 enum class Screens {
+    LOGIN,
     RECENTS,
     FOLDERS,
     ADDNEW,

--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/auth/LoginScreen.kt
@@ -12,13 +12,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
 import xyz.graphitenerd.tassel.R
 import xyz.graphitenerd.tassel.screens.AuthViewModel

--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/auth/LoginScreen.kt
@@ -1,0 +1,162 @@
+package xyz.graphitenerd.tassel.screens.auth
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.firebase.ui.auth.AuthUI
+import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
+import xyz.graphitenerd.tassel.R
+import xyz.graphitenerd.tassel.screens.AuthViewModel
+
+@Composable
+fun LoginScreen(
+    authViewModel: AuthViewModel,
+    onSignInSuccess: () -> Unit
+) {
+    val userDetails by authViewModel.userDetails.collectAsState()
+
+    val signInLauncher = rememberLauncherForActivityResult(
+        FirebaseAuthUIActivityResultContract()
+    ) { result ->
+        authViewModel.onSignInResult(result)
+        if (authViewModel.hasUser()) {
+            onSignInSuccess()
+        }
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            // App Logo
+            Image(
+                painter = painterResource(id = R.drawable.tassel_app_icon),
+                contentDescription = "Tassel Logo",
+                modifier = Modifier.size(120.dp)
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // App Title
+            Text(
+                text = "Tassel",
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Subtitle
+            Text(
+                text = "Your personal bookmark manager",
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Google Sign-In Button
+            Button(
+                onClick = {
+                    signInLauncher.launch(authViewModel.signInIntent)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        painter = painterResource(id = android.R.drawable.ic_dialog_email),
+                        contentDescription = "Google Icon",
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "Sign in with Google",
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Email Sign-In Button
+            OutlinedButton(
+                onClick = {
+                    signInLauncher.launch(authViewModel.signInIntent)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onBackground
+                )
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Email,
+                        contentDescription = "Email Icon",
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "Sign in with Email",
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Privacy Text
+            Text(
+                text = "By continuing, you agree to Tassel's Terms of Service\nand Privacy Policy",
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                textAlign = TextAlign.Center,
+                lineHeight = 16.sp
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+        }
+    }
+}

--- a/app/src/main/java/xyz/graphitenerd/tassel/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/graphitenerd/tassel/screens/settings/SettingsScreen.kt
@@ -1,0 +1,260 @@
+package xyz.graphitenerd.tassel.screens.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import xyz.graphitenerd.tassel.screens.AuthViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    authViewModel: AuthViewModel,
+    onSignOut: () -> Unit = {}
+) {
+    val userDetails by authViewModel.userDetails.collectAsState()
+    var showSignOutDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Settings",
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            // User Profile Card
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 24.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Profile Picture or Placeholder
+                    if (userDetails?.photoUrl?.isNotEmpty() == true) {
+                        AsyncImage(
+                            model = userDetails?.photoUrl,
+                            contentDescription = "Profile Picture",
+                            modifier = Modifier
+                                .size(64.dp)
+                                .clip(CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .size(64.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.primary),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Person,
+                                contentDescription = "Profile Icon",
+                                modifier = Modifier.size(32.dp),
+                                tint = MaterialTheme.colorScheme.onPrimary
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    Column {
+                        Text(
+                            text = userDetails?.displayName?.ifEmpty { "User" } ?: "User",
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = userDetails?.email ?: "Not signed in",
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+            }
+
+            // Settings Sections
+            Text(
+                text = "Account",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)
+            )
+
+            SettingsItem(
+                icon = Icons.Default.Info,
+                title = "Account Info",
+                subtitle = "Manage your account details",
+                onClick = { /* TODO: Navigate to account info */ }
+            )
+
+            SettingsItem(
+                icon = Icons.Default.ExitToApp,
+                title = "Sign Out",
+                subtitle = "Sign out of your account",
+                onClick = { showSignOutDialog = true },
+                iconTint = MaterialTheme.colorScheme.error
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // App Settings
+            Text(
+                text = "App Settings",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)
+            )
+
+            SettingsItem(
+                icon = Icons.Default.Notifications,
+                title = "Notifications",
+                subtitle = "Manage notification preferences",
+                onClick = { /* TODO: Navigate to notifications settings */ }
+            )
+
+            SettingsItem(
+                icon = Icons.Default.Star,
+                title = "About",
+                subtitle = "Version 1.0",
+                onClick = { /* TODO: Navigate to about screen */ }
+            )
+        }
+
+        // Sign Out Confirmation Dialog
+        if (showSignOutDialog) {
+            AlertDialog(
+                onDismissRequest = { showSignOutDialog = false },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.ExitToApp,
+                        contentDescription = "Sign Out"
+                    )
+                },
+                title = {
+                    Text(text = "Sign Out")
+                },
+                text = {
+                    Text(text = "Are you sure you want to sign out?")
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            authViewModel.signOut()
+                            showSignOutDialog = false
+                            onSignOut()
+                        },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error
+                        )
+                    ) {
+                        Text("Sign Out")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showSignOutDialog = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun SettingsItem(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    iconTint: Color = MaterialTheme.colorScheme.primary
+) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = title,
+                modifier = Modifier.size(24.dp),
+                tint = iconTint
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = subtitle,
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
+            }
+
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowRight,
+                contentDescription = "Navigate",
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+            )
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a complete Google Sign-In feature using Firebase Authentication and FirebaseUI Auth library.

Changes:
- Created LoginScreen with Google and Email sign-in options
- Created SettingsScreen with user profile display and sign-out functionality
- Added LOGIN screen to navigation with proper routing
- Updated MainActivity to check authentication state on startup
- Added signOut() method to AuthViewModel
- Implemented authentication state management with navigation flow

The login flow:
1. Users see LoginScreen if not authenticated
2. Can sign in with Google or Email via FirebaseUI
3. Upon successful sign-in, navigate to home screen
4. Can sign out from Settings screen

Dependencies already in place:
- Firebase Auth KTX (firebase-auth-ktx)
- FirebaseUI Auth (firebase-ui-auth:7.2.0)
- OAuth client configured in google-services.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)